### PR TITLE
Hide AI suggested prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # Hide LI (LinkedIn) Collab Articles
 
 ## Abstract
-This Chrome extension hides all collaborative articles on the LinkedIn homepage. 
+
+This Chrome extension hides all collaborative articles and AI generated prompts on the LinkedIn homepage.
 
 ## Tech Stack
+
 This project uses vanilla JS, CSS, and HTML.
 
-## Setup/Installation
+## Installation
+
 You can clone the repo locally using `git clone`.
 
-[This article](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) offers detailed instructions on loading an unpacked chrome extension. You can navigate to the extensions page via the puzzle piece icon in the toolbar. Enable "developer mode" on the top-right. From there, you can click "load unpacked extension" and choose the folder via the popup. You should then see the writing icon appear in the toolbar. When you click on it, you can see "Hide LI Collab Articles." From there, you can navigate to the LinkedIn homepage (linkedin.com/feed). As you scroll through your feed you shouldn't see any collaborative articles. If you do, please open an issue. 
+## Setup
+
+### Chrome
+
+[This article](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) offers detailed instructions on loading an unpacked chrome extension. You can navigate to the extensions page via the puzzle piece icon in the toolbar. Enable "developer mode" on the top-right. From there, you can click "load unpacked extension" and choose the folder via the popup. You should then see the writing icon appear in the toolbar. When you click on it, you can see "Hide LI Collab Articles." From there, you can navigate to the LinkedIn homepage (linkedin.com/feed). As you scroll through your feed you shouldn't see any collaborative articles. If you do, please open an issue.
 
 ## Screenshots
 
 ## Future Changes
-Eventually I want to port all of my extensions to Firefox. 
 
+Eventually I want to port all of my extensions to Firefox.

--- a/css/global.css
+++ b/css/global.css
@@ -3,3 +3,7 @@ div.feed-shared-update-v2:has(div):has(div):has(a.app-aware-link):has(
   ) {
   display: none !important;
 }
+
+button[class*='feed-shared-coach-prompt'] {
+  display: none !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,37 +1,32 @@
 {
   "manifest_version": 3,
   "name": "Hide LI Collab Articles",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "This Chrome browser extension hides collaborative articles on LinkedIn.",
-   "permissions": ["scripting"],
+  "permissions": ["scripting"],
   "icons": {
     "16": "images/writing-emoji-16.png",
     "32": "images/writing-emoji-32.png",
     "48": "images/writing-emoji-48.png",
     "128": "images/writing-emoji-128.png"
-},
-"background": {
+  },
+  "background": {
     "service_worker": "scripts/background.js"
-},
-"web_accessible_resources": [
-  {
-    "resources": ["css/*.css"],
-    "extension_ids": []
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["css/*.css"],
+      "extension_ids": []
     }
   ],
-"content_scripts": [
+  "content_scripts": [
     {
-        "matches": [
-        "*://www.linkedin.com/feed"
-      ],
+      "matches": ["*://www.linkedin.com/feed"],
       "css": ["css/global.css"]
     }
-],
-  "host_permissions": [
-    "*://www.linkedin.com/feed"
   ],
+  "host_permissions": ["*://www.linkedin.com/feed"],
   "action": {
-      "default_popup": "popup.html"
+    "default_popup": "popup.html"
   }
-
 }

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LI Collab Articles</h2>
     <p>
-      version: 0.0.1 |
+      version: 0.0.2 |
       <a
         href="https://github.com/garnetred/hide-li-collab-articles"
         style="color: navy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change hides the carousel of AI prompts that appears below many posts on LinkedIn.
<!--- Describe your changes in detail -->

## Background
Recently LinkedIn rolled out a change where AI-generated prompts are added to the bottom of posts in a carousel. Many people have complained. Since this extension already hides AI-generated collab articles, I figured people interested in this extension would also be interested in this feature. It works by removing any elements where the class name starts with `feed-shared-coach-prompt` from the DOM. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can load the unpacked extension while in developer mode in Chrome. From there, when the extension is enabled and you navigate to your LinkedIn home feed, you shouldn't see collab articles or the AI prompts. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [x] I have updated any relevant documentation.
