### PR TITLE
Hide prompts on job postings and star symbol on posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 ## Abstract
 
 This Chrome extension hides the following on LinkedIn:
+
 - all collaborative articles on the home page
--  AI generated prompts below posts and on job postings
--  the star symbol that prompts users to upgrade to see post summaries.
+- AI generated prompts below posts and on job postings
+- the star symbol that prompts users to upgrade to see post summaries.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## Abstract
 
-This Chrome extension hides all collaborative articles and AI generated prompts on the LinkedIn homepage.
+This Chrome extension hides the following on LinkedIn:
+- all collaborative articles on the home page
+-  AI generated prompts below posts and on job postings
+-  the star symbol that prompts users to upgrade to see post summaries.
 
 ## Tech Stack
 

--- a/css/global.css
+++ b/css/global.css
@@ -4,6 +4,18 @@ div.feed-shared-update-v2:has(div):has(div):has(a.app-aware-link):has(
   display: none !important;
 }
 
+/* ai prompt below posts */
 button[class*='feed-shared-coach-prompt'] {
+  display: none !important;
+}
+
+/* ai prompt on job pages */
+
+[class*='coach-'] {
+  display: none !important;
+}
+
+/* star symbol at top right of each post */
+[aria-owns*='coach-'] {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,11 +21,11 @@
   ],
   "content_scripts": [
     {
-      "matches": ["*://www.linkedin.com/feed"],
+      "matches": ["*://www.linkedin.com/*"],
       "css": ["css/global.css"]
     }
   ],
-  "host_permissions": ["*://www.linkedin.com/feed"],
+  "host_permissions": ["*://www.linkedin.com/*"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide LI Collab Articles",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "This Chrome browser extension hides collaborative articles on LinkedIn.",
   "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide LI Collab Articles</h2>
     <p>
-      version: 0.0.2 |
+      version: 0.0.3 |
       <a
         href="https://github.com/garnetred/hide-li-collab-articles"
         style="color: navy"

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -3,7 +3,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (
     changeInfo.status === 'complete' &&
     tabUrl &&
-    tabUrl.includes('linkedin.com/feed')
+    tabUrl.includes('linkedin.com')
   ) {
     chrome.scripting.insertCSS({
       target: { tabId: tabId },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change hides generative AI prompts on job postings and the star that, when clicked, opens up another panel to convince you to upgrade. 
<!--- Describe your changes in detail -->

## Background
These changes were added within the last week and may detract from the experience for some users, so I've created a way by which people can opt out. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can clone the repo, switch to this branch, and load the unpacked extension into Chrome in developer mode. Once the extension has been enabled you should no longer see the AI prompts everywhere. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
<img width="594" alt="Screen Shot 2024-05-24 at 12 54 44 PM" src="https://github.com/garnetred/hide-li-collab-articles/assets/59572865/9ab35428-ef90-48f7-ab3f-26fac384f4e0">

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [x] I have updated any relevant documentation.
